### PR TITLE
Fix css syntax error in utilities

### DIFF
--- a/src/renderer/react-app/src/index.css
+++ b/src/renderer/react-app/src/index.css
@@ -1,7 +1,9 @@
 /* Optimized: Use font-display: swap for better performance */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* Base styles */
 body {


### PR DESCRIPTION
Fix CSS syntax error by updating Tailwind CSS import directives.

The previous `@import "tailwindcss"` syntax was causing a CSS minification warning, indicating an expected semicolon but finding a closing brace. This change updates the Tailwind CSS directives to the correct v3 syntax, resolving the build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d100c67-973c-4ca6-aa76-f8c850df72c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d100c67-973c-4ca6-aa76-f8c850df72c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

